### PR TITLE
update ansible tower add source workflow

### DIFF
--- a/doc/modules/con_Adding_sources.adoc
+++ b/doc/modules/con_Adding_sources.adoc
@@ -5,6 +5,9 @@
 
 Sources are the platforms [product-title] connects to in order to collect inventory information used to organize and present products available to users. To use [product-title_short], you need to connect the application to at least one source.
 
+
+=== Adding an Ansible Tower source
+
 Connect an Ansible Tower instance to [product-title] to create portfolios from its inventory of playbooks and workflows your users can view and order from.
 
 include::proc_Adding_sources.adoc[]

--- a/doc/modules/con_Adding_sources.adoc
+++ b/doc/modules/con_Adding_sources.adoc
@@ -3,10 +3,10 @@
 [id="Adding_sources"]
 == Adding sources
 
-Sources are the platforms [product-title] connects to in order to collect information on products available to users. To use [product-title_short], you need to connect the application to at least one source.
+Sources are the platforms [product-title] connects to in order to collect inventory information used to organize and present products available to users. To use [product-title_short], you need to connect the application to at least one source.
 
 Connect an Ansible Tower instance to [product-title] to create portfolios from its inventory of playbooks and workflows your users can view and order from.
 
 include::proc_Adding_sources.adoc[]
 
-After you connect your Ansbile Tower instance, navigate back to [product-title] to create portfolios and assign approval processes using the Ansible Tower's inventory. 
+After connecting your Ansbile Tower instance, navigate back to [product-title_short] to create portfolios and assign approval processes using the Ansible Tower's inventory.

--- a/doc/modules/con_Adding_sources.adoc
+++ b/doc/modules/con_Adding_sources.adoc
@@ -5,11 +5,10 @@
 
 Sources are the platforms [product-title] connects to in order to collect inventory information used to organize and present products available to users. To use [product-title_short], you need to connect the application to at least one source.
 
-
 === Adding an Ansible Tower source
 
-Connect an Ansible Tower instance to [product-title] to create portfolios from its inventory of playbooks and workflows your users can view and order from.
+Connect an Ansible Tower instance to [product-title] to create products from its inventory of playbooks and workflows your users can view and order from.
 
 include::proc_Adding_sources.adoc[]
 
-After connecting your Ansbile Tower instance, navigate back to [product-title_short] to create portfolios and assign approval processes using the Ansible Tower's inventory.
+After connecting your Ansible Tower instance, navigate back to [product-title_short] to review templates available on that platform, and add those products to your portfolios.

--- a/doc/modules/con_Adding_sources.adoc
+++ b/doc/modules/con_Adding_sources.adoc
@@ -3,6 +3,10 @@
 [id="Adding_sources"]
 == Adding sources
 
-Sources are the platforms Catalog connects to in order to collect information on products available to users to order. To use Catalog, you need to connect the application to at least once source.
+Sources are the platforms [product-title] connects to in order to collect information on products available to users. To use [product-title_short], you need to connect the application to at least one source.
+
+Connect an Ansible Tower instance to [product-title] to create portfolios from its inventory of playbooks and workflows your users can view and order from.
 
 include::proc_Adding_sources.adoc[]
+
+After you connect your Ansbile Tower instance, navigate back to [product-title] to create portfolios and assign approval processes using the Ansible Tower's inventory. 

--- a/doc/modules/proc_Adding_ansible_tower_source.adoc
+++ b/doc/modules/proc_Adding_ansible_tower_source.adoc
@@ -1,0 +1,16 @@
+
+To add an Ansible Tower source:
+
+. Click menu:Settings.
+. Select *Sources*
+. Click *Add source*.
+. Enter the source *Name* and click *Next*.
+. Select *Catalog* from the available applications.
+. Select *Ansible Tower* as the *source type*.
+. Enter *user name* and *Secret Key* credentials.
+. Provide the Ansible Tower endpoint *URL*
+. (Optional) Toggle the switch to verify the endpoint SSL certificate.
+.. Enter the  SSL certificate in the *Certificate Authority* field.
+. Click *Next*.
+. Review your Ansible Tower source details.
+. Click *Finish* to add your source.


### PR DESCRIPTION
Updating workflow for adding Ansible Tower source. This PR:

- Adds context to why an org adds a source
- Adds context to adding Ansible Tower
- Up-to-date with UI Ansible Tower source workflow
- Removes Receptor related features from catalog-specific source workflow