### PR TITLE
Update edit portfolios

### DIFF
--- a/doc/modules/con_Assigning_approval_workflow.adoc
+++ b/doc/modules/con_Assigning_approval_workflow.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 // assembly_Administration_guide.adoc
 [id="Assigning_approval_workflow"]
-= Assigning approval workflows to portfolios
+= Setting approval processes for portfolios
 
-Assign approval workflows, once created, to your portfolios. Each approval workflow will apply to all products in a given portfolio.
+Govern access to products by setting the approval processes for the portfolios in which they are organized. Once approval processes are set for a portfolio, each product ordered in that portfolio will require approval from the groups defined in the process. Approval processes will apply to all products in a given portfolio.
 
 include::proc_Assigning_approval_workflow.adoc[]

--- a/doc/modules/con_Assigning_approval_workflow.adoc
+++ b/doc/modules/con_Assigning_approval_workflow.adoc
@@ -3,6 +3,6 @@
 [id="Assigning_approval_workflow"]
 = Setting approval processes for portfolios
 
-Govern access to products by setting the approval processes for the portfolios in which they are organized. Once approval processes are set for a portfolio, each product ordered in that portfolio will require approval from the groups defined in the process. Approval processes will apply to all products in a given portfolio.
+Govern access to products by setting the approval processes for the portfolios in which they are organized. Once approval processes are set for a portfolio, each product ordered in that portfolio will require approval from the groups defined in the process.
 
 include::proc_Assigning_approval_workflow.adoc[]

--- a/doc/modules/con_Editing_portfolios.adoc
+++ b/doc/modules/con_Editing_portfolios.adoc
@@ -2,6 +2,6 @@
 [id="Editing_portfolios"]
 == Editing portfolios
 
-Editing portfolios allows you to change information related to a portfolio's name, description and its approval workflow.
+Editing portfolios allows you to change information related to a portfolio's name and description.
 
 include::proc_Editing_portfolios.adoc[]

--- a/doc/modules/proc_Assigning_approval_workflow.adoc
+++ b/doc/modules/proc_Assigning_approval_workflow.adoc
@@ -2,5 +2,5 @@ Procedure
 
 . Navigate to menu:Portfolio.
 . Click image:more_actions.pmg[More Actions] on a portfolio tile and select *Set approval*.
-. From the *Select approval process* field, choose those processes to add to the portfolio.
+. From the *Select approval process* field, choose those processes to set to the portfolio.
 . Click *Save*.

--- a/doc/modules/proc_Assigning_approval_workflow.adoc
+++ b/doc/modules/proc_Assigning_approval_workflow.adoc
@@ -1,6 +1,6 @@
 Procedure
 
 . Navigate to menu:Portfolio.
-. Click image:more_actions.pmg[More Actions] on a portfolio tile and select *Edit*.
-. On the *Edit Portfolio* modal select an *Approval workflow* from the drop-down.
+. Click image:more_actions.pmg[More Actions] on a portfolio tile and select *Set approval*.
+. From the *Select approval process* field, choose those processes to add to the portfolio.
 . Click *Save*.

--- a/doc/modules/proc_Editing_portfolios.adoc
+++ b/doc/modules/proc_Editing_portfolios.adoc
@@ -2,5 +2,5 @@ To edit a portfolio:
 
 . Click *Portfolios*.
 . Click image:more_actions.png[More Actions] on a portfolio, then click *Edit*.
-. Update the *Name*, * Description* or *Approval workflow*.
+. Update the *Name* and/or *Description*.
 . Click *Save*.


### PR DESCRIPTION
This PR updates the edit portfolio workflow:

1. Editing Portfolios is limited to the current state of edit -> change name and description.
2. Set approval process description is updated and the procedure for applying an approval process to a portfolio is now current. 